### PR TITLE
Fix for Update 6

### DIFF
--- a/Config/AccessTransformers.ini
+++ b/Config/AccessTransformers.ini
@@ -1,4 +1,5 @@
 [AccessTransformers]
+Friend=(Class="AFGBuildable", FriendClass="FAABuildingsDataHelper")
 Friend=(Class="AFGBuildableFactory", FriendClass="FAABuildingsDataHelper")
 Friend=(Class="AFGBuildableFactory", FriendClass="UAACopyBuildingsComponent")
 Friend=(Class="AFGBuildableConveyorBase", FriendClass="UAACopyBuildingsComponent")

--- a/Source/AreaActions/Private/AAAreaActionsComponent.cpp
+++ b/Source/AreaActions/Private/AAAreaActionsComponent.cpp
@@ -219,7 +219,9 @@ void UAAAreaActionsComponent::RemoveCorner(const int CornerIdx) {
 
 void UAAAreaActionsComponent::UpdateExtraActors() const
 {
-	UFGOutlineComponent::Get(GetWorld())->ShowDismantlePendingMaterial(this->ExtraActors);
+	UFGOutlineComponent* Outline = UFGOutlineComponent::Get(GetWorld());
+	Outline->HideOutline();
+	Outline->ShowDismantlePendingMaterial(this->ExtraActors);
 }
 
 void UAAAreaActionsComponent::DelayedUpdateExtraActors()

--- a/Source/AreaActions/Private/AABlueprint.cpp
+++ b/Source/AreaActions/Private/AABlueprint.cpp
@@ -162,6 +162,7 @@ void UAABlueprint::SerializeData()
 	FAAObjectReferenceArchive DataAr(DataWriter, ObjectsToSerialize);
 	DataAr.SetIsLoading(false);
 	DataAr.SetIsSaving(true);
+	DataAr.ArNoDelta = true;
     
 	for(UObject* Object : ObjectsToSerialize)
 		Object->Serialize(DataAr);
@@ -197,7 +198,7 @@ FArchive& operator<<(FArchive& Ar, FAABlueprintObjectTOC& BuildingTOC)
 {
 	Ar << BuildingTOC.Class;
 	Ar << BuildingTOC.Name;
-	if(Ar.IsLoading())
+	if(!Ar.IsLoading())
 	{
 		uint32 FlagsInt = static_cast<uint32>(BuildingTOC.Flags);
 		Ar << FlagsInt;

--- a/Source/AreaActions/Private/AABlueprintFunctionLibrary.cpp
+++ b/Source/AreaActions/Private/AABlueprintFunctionLibrary.cpp
@@ -80,7 +80,8 @@ bool UAABlueprintFunctionLibrary::TakeItemsFromInventories(const TArray<UFGInven
 {
 	if(!InventoriesHaveEnoughItems(Inventories, Items, MissingItems))
 		return false;
-	
+
+	MissingItems = Items;
 	for(UFGInventoryComponent* Inventory : Inventories)
 	{
 		TArray<FInventoryStack> Stacks;
@@ -99,5 +100,5 @@ bool UAABlueprintFunctionLibrary::TakeItemsFromInventories(const TArray<UFGInven
 		}
 	}
 
-	return MissingItems.Num() == 0;
+	return true;
 }

--- a/Source/AreaActions/Private/AABuildingsDataHelper.cpp
+++ b/Source/AreaActions/Private/AABuildingsDataHelper.cpp
@@ -97,10 +97,11 @@ TMap<TSubclassOf<UFGItemDescriptor>, int32> FAABuildingsDataHelper::CalculateBui
 	{
 		if(AFGBuildable* Buildable = Cast<AFGBuildable>(Object))
 		{
+			int32 Multiplier = Buildable->GetDismantleRefundReturnsMultiplier(); // For conveyors, pipes, etc
 			{
 				TArray<FItemAmount> BuildingIngredients = UFGRecipe::GetIngredients(Buildable->GetBuiltWithRecipe());
 				for(const FItemAmount ItemAmount : BuildingIngredients)
-					RequiredItems.FindOrAdd(ItemAmount.ItemClass) += ItemAmount.Amount;
+					RequiredItems.FindOrAdd(ItemAmount.ItemClass) += ItemAmount.Amount * Multiplier;
 			}
 		}
 	}

--- a/Source/AreaActions/Private/AAObjectCollectorArchive.cpp
+++ b/Source/AreaActions/Private/AAObjectCollectorArchive.cpp
@@ -56,7 +56,7 @@ bool FAAObjectCollectorArchive::ShouldSave(UObject* Object) const
         if(!RootObjects.Contains(Actor->GetOwner())) return false;
     }
     if(Object->HasAnyFlags(RF_WasLoaded)) return false;
-    return true;
+    return Object->IsInOuter(CurrentObject);
 }
 
 FArchive& FAAObjectCollectorArchive::operator<<(UObject*& Value)
@@ -92,4 +92,3 @@ FArchive& FAAObjectCollectorArchive::operator<<(FWeakObjectPtr& Value)
     return *this;
 }
 
-const FGuid FSaveCustomVersion::GUID = FGuid(0x21043E2F, 0x13E61FD6, 0x513B9D51, 0x3636A230); //See symbol ?GUID@FSaveCustomVersion@@2UFGuid@@B in IDA for value <21043E2Fh, 13E61FD6h, 513B9D51h, 3636A230h>

--- a/Source/AreaActions/Private/AAObjectValidatorArchive.cpp
+++ b/Source/AreaActions/Private/AAObjectValidatorArchive.cpp
@@ -30,7 +30,7 @@ bool FAAObjectValidatorArchive::IsValid(UObject* Object) const
     {
         if(Actor->GetOwner() == Object) return true;
     }
-    return AllObjects.Contains(Object);
+    return !Object->IsInOuter(CurrentObject) || AllObjects.Contains(Object);
 }
 
 void FAAObjectValidatorArchive::SetInvalid(UObject* InvalidObject)


### PR DESCRIPTION
1. Fixed compilation for Update 6
2. Hide outlines when deselecting objects one by one
3. Fixed many difficult to catch crashes in GC and when placing blueprints (mainly by fixing object flags serialization)
4. Items are now taken from the inventory again
5. Respect dismantle multipliers for blueprint build costs (fixes conveyor & pipe costs)

**Known issues**
1. Selecting objects one by one still looks ugly (only some parts of the building are highlighted), I couldn't find a method which could fully highlight multiple buildings (how does vanilla multiple selection work BTW?)
2. Weird build gun behavior, it may be still shown after all actions are closed, or be hidden when building blueprints (observed when blueprint was selected by hotkey)
3. CalculateBoundingBox segfaults at addr=0 when creating blueprint with only one conveyor
4. Factory legs are not copied
5. Placing blueprint with pipes & junctions and then trying to attach pipe to junction crashes